### PR TITLE
Add Whisper-1 support

### DIFF
--- a/gui/src/pages/Settings.tsx
+++ b/gui/src/pages/Settings.tsx
@@ -318,6 +318,7 @@ const Settings = () => {
                   <SelectContent>
                     <SelectItem value="gpt-4o-transcribe">gpt-4o-transcribe (More accurate, more expensive)</SelectItem>
                     <SelectItem value="gpt-4o-mini-transcribe">gpt-4o-mini-transcribe (Less accurate, faster, less expensive)</SelectItem>
+                    <SelectItem value="whisper-1">whisper-1 (Legacy Whisper model)</SelectItem>
                   </SelectContent>
                 </Select>
               )}


### PR DESCRIPTION
## Summary
- allow selecting Whisper-1 in the transcription model dropdown
- handle Whisper-1 in backend transcription logic

## Testing
- `python -m compileall vaibvoice`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685795cdb784832ea3e652205d86d890